### PR TITLE
Remove incorrectly used isystem flag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,8 +22,8 @@ ifeq ($(SCIDB_THIRDPARTY_PREFIX),)
 endif
 #
 #   # Debug:
-#CFLAGS=-pedantic -W -Wextra -Wall -Wno-variadic-macros -Wno-strict-aliasing -Wno-long-long -Wno-unused-parameter -fPIC -D_STDC_FORMAT_MACROS -Wno-system-headers -isystem -g -ggdb3  -D_STDC_LIMIT_MACROS
-CFLAGS=-pedantic -W -Wextra -Wall -Wno-unused-parameter -Wno-variadic-macros -Wno-strict-aliasing -Wno-long-long -Wno-unused -fPIC -D_STDC_FORMAT_MACROS -Wno-system-headers -isystem -O3 -DNDEBUG -D_STDC_LIMIT_MACROS
+#CFLAGS=-pedantic -W -Wextra -Wall -Wno-variadic-macros -Wno-strict-aliasing -Wno-long-long -Wno-unused-parameter -fPIC -D_STDC_FORMAT_MACROS -Wno-system-headers -g -ggdb3  -D_STDC_LIMIT_MACROS
+CFLAGS=-pedantic -W -Wextra -Wall -Wno-unused-parameter -Wno-variadic-macros -Wno-strict-aliasing -Wno-long-long -Wno-unused -fPIC -D_STDC_FORMAT_MACROS -Wno-system-headers -O3 -DNDEBUG -D_STDC_LIMIT_MACROS
 INC=-I. -I./asof/ -I./extern -DPROJECT_ROOT="\"$(SCIDB)\"" -I"$(SCIDB_THIRDPARTY_PREFIX)/3rdparty/boost/include/" -I"$(SCIDB)/include"
 LIBS=-shared -Wl,-soname,libaxial_aggregate.so -L. -L"$(SCIDB_THIRDPARTY_PREFIX)/3rdparty/boost/lib" -L"$(SCIDB)/lib" -Wl,-rpath,$(SCIDB)/lib:$(RPATH) -lm
 


### PR DESCRIPTION
The `-isystem` flag needs to be followed by a directory, see [here](https://gcc.gnu.org/onlinedocs/gcc/Directory-Options.html). Without the patch, the flag following `-isystem` is treated as a directory and has no effect.